### PR TITLE
Return 500 errors for command timeout

### DIFF
--- a/bumper/confserver.py
+++ b/bumper/confserver.py
@@ -1164,7 +1164,7 @@ class ConfServer:
                             json_body["toId"]
                         )
                     )
-                    body = {"id": randomid, "errno": bumper.ERR_COMMON, "ret": "fail"}
+                    body = {"id": randomid, "errno": 500, "ret": "fail", "debug": "wait for response timed out"}
                     return web.json_response(body)
             
             else:

--- a/bumper/mqttserver.py
+++ b/bumper/mqttserver.py
@@ -142,11 +142,13 @@ class MQTTHelperBot:
                             self.command_responses.set(cresp)
                             return resp
 
-            return {"id": requestid, "errno": "timeout", "ret": "fail"}
+            return {"id": requestid, "errno": 500, "ret": "fail", "debug": "wait for response timed out"}
         except asyncio.CancelledError as e:
             helperbotlog.debug("wait_for_resp cancelled by asyncio")
+            return {"id": requestid, "errno": 500, "ret": "fail", "debug": "wait for response timed out"}
         except Exception as e:
             helperbotlog.exception("{}".format(e))
+            return {"id": requestid, "errno": 500, "ret": "fail", "debug": "wait for response timed out"}
 
     async def send_command(self, cmdjson, requestid):
         try:


### PR DESCRIPTION
Bumper was returning an invalid errno when a command for MQTT would timeout.  Change to return a 500 errno with a debug message.

Closes #31