### PR TITLE
handle #55

### DIFF
--- a/bumper/confserver.py
+++ b/bumper/confserver.py
@@ -489,7 +489,10 @@ class ConfServer:
                 bumper.user_add_device(tmpuser["userid"], user_devid)
 
             for bot in bots:  # Add all bots to the user
-                bumper.user_add_bot(tmpuser["userid"], bot["did"])
+                if "did" in bot:
+                    bumper.user_add_bot(tmpuser["userid"], bot["did"])
+                else:
+                    confserverlog.error("No DID for bot: {}".format(bot))
 
             if "checkLogin" in request.path:  # If request was to check a token do so
                 checkToken = self.check_token(

--- a/bumper/db.py
+++ b/bumper/db.py
@@ -309,7 +309,10 @@ def bot_toEcoVacsHome_JSON(bot):  # EcoVacs Home
 def bot_full_upsert(vacbot):
     bots = db_get().table("bots")
     Bot = Query()
-    bots.upsert(vacbot, Bot.did == vacbot["did"])
+    if "did" in vacbot:
+        bots.upsert(vacbot, Bot.did == vacbot["did"])
+    else:
+        bumperlog.error("No DID in vacbot: {}".format(vacbot))
 
 
 def bot_set_nick(did, nick):

--- a/tests/test_confserver.py
+++ b/tests/test_confserver.py
@@ -84,7 +84,7 @@ async def test_login(aiohttp_client):
     assert "username" in jsonresp["data"]
 
     remove_existing_db()
-    bumper.db = "tests/tmp.db"  # Set db location for testing
+    bumper.db = "tests/tmp.db"  # Set db location for testing 
 
     # Test global_e without user
     resp = await client.get("/v1/private/us/en/dev_1234/global_e/1/0/0/user/login")
@@ -109,6 +109,25 @@ async def test_login(aiohttp_client):
 
     # Add a bot to db that will be added to user
     bumper.bot_add("sn_123", "did_123", "dev_123", "res_123", "com_123")
+    resp = await client.get("/v1/private/us/en/dev_1234/ios/1/0/0/user/login")
+    assert resp.status == 200
+    text = await resp.text()
+    jsonresp = json.loads(text)
+    assert jsonresp["code"] == bumper.RETURN_API_SUCCESS
+    assert "accessToken" in jsonresp["data"]
+    assert "uid" in jsonresp["data"]
+    assert "username" in jsonresp["data"]
+
+    # Add a bot to db that doesn't have a did
+    newbot = {
+            "class": "dev_1234",
+            "company": "com_123",
+            #"did": self.did,
+            "name": "sn_1234",            
+            "resource": "res_1234",            
+    }
+    bumper.bot_full_upsert(newbot)
+
     resp = await client.get("/v1/private/us/en/dev_1234/ios/1/0/0/user/login")
     assert resp.status == 200
     text = await resp.text()


### PR DESCRIPTION
Better handling if a bot is missing a DID, which could be a corrupt or outdated database.
Helps with #55 