### PR TITLE
Ensure all bots are returned during getProductIotMap

### DIFF
--- a/bumper/confserver.py
+++ b/bumper/confserver.py
@@ -855,74 +855,7 @@ class ConfServer:
         try:
             body = {
                 "code": bumper.RETURN_API_SUCCESS,
-                "data": [
-                    {
-                        "classid": "dl8fht",
-                        "product": {
-                            "_id": "5acb0fa87c295c0001876ecf",
-                            "name": "DEEBOT 600 Series",
-                            "icon": "5acc32067c295c0001876eea",
-                            "UILogicId": "dl8fht",
-                            "ota": False,
-                            "iconUrl": "https://portal-ww.ecouser.net/api/pim/file/get/5acc32067c295c0001876eea",
-                        },
-                    },
-                    {
-                        "classid": "02uwxm",
-                        "product": {
-                            "_id": "5ae1481e7ccd1a0001e1f69e",
-                            "name": "DEEBOT OZMO Slim10 Series",
-                            "icon": "5b1dddc48bc45700014035a1",
-                            "UILogicId": "02uwxm",
-                            "ota": False,
-                            "iconUrl": "https://portal-ww.ecouser.net/api/pim/file/get/5b1dddc48bc45700014035a1",
-                        },
-                    },
-                    {
-                        "classid": "y79a7u",
-                        "product": {
-                            "_id": "5b04c0227ccd1a0001e1f6a8",
-                            "name": "DEEBOT OZMO 900",
-                            "icon": "5b04c0217ccd1a0001e1f6a7",
-                            "UILogicId": "y79a7u",
-                            "ota": True,
-                            "iconUrl": "https://portal-ww.ecouser.net/api/pim/file/get/5b04c0217ccd1a0001e1f6a7",
-                        },
-                    },
-                    {
-                        "classid": "jr3pqa",
-                        "product": {
-                            "_id": "5b43077b8bc457000140363e",
-                            "name": "DEEBOT 711",
-                            "icon": "5b5ac4cc8d5a56000111e769",
-                            "UILogicId": "jr3pqa",
-                            "ota": True,
-                            "iconUrl": "https://portal-ww.ecouser.net/api/pim/file/get/5b5ac4cc8d5a56000111e769",
-                        },
-                    },
-                    {
-                        "classid": "uv242z",
-                        "product": {
-                            "_id": "5b5149b4ac0b87000148c128",
-                            "name": "DEEBOT 710",
-                            "icon": "5b5ac4e45f21100001882bb9",
-                            "UILogicId": "uv242z",
-                            "ota": True,
-                            "iconUrl": "https://portal-ww.ecouser.net/api/pim/file/get/5b5ac4e45f21100001882bb9",
-                        },
-                    },
-                    {
-                        "classid": "ls1ok3",
-                        "product": {
-                            "_id": "5b6561060506b100015c8868",
-                            "name": "DEEBOT 900 Series",
-                            "icon": "5ba4a2cb6c2f120001c32839",
-                            "UILogicId": "ls1ok3",
-                            "ota": True,
-                            "iconUrl": "https://portal-ww.ecouser.net/api/pim/file/get/5ba4a2cb6c2f120001c32839",
-                        },
-                    },
-                ],
+                "data": EcoVacsHomeProducts,
             }
             return web.json_response(body)
 


### PR DESCRIPTION
Fixes #69.
Based on the list in the handler, I wrote a filter function for the `EcoVacsHomeProducts` list. Basically removing `supportType` from the items. After double checking with the captured traffic I created for myself, I realized the payload actually contains `supportType`. Therefore, using `EcoVacsHomeProducts` is just fine. However, I am not sure which impact it has on the `DEEBOT 2017` app. Probably none.