### PR TITLE
Update .dockerignore to not exclude the certs folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,6 @@ examples
 # Docs
 docs
 
-# Certs
-certs
-
 .coverage
 
 # Markdown


### PR DESCRIPTION
So that your built certs get baked into the image when you do a `docker build`